### PR TITLE
refactor: add explicit SCIM API headers for proper content negotiation

### DIFF
--- a/src/main/java/org/kohsuke/github/GHEnterpriseExt.java
+++ b/src/main/java/org/kohsuke/github/GHEnterpriseExt.java
@@ -20,6 +20,8 @@ public class GHEnterpriseExt extends GHOrganization {
     }
 
     public SCIMEMUUser createSCIMEMUUser(SCIMEMUUser newUser) throws IOException {
+        newUser.schemas = new String[]{SCIMConstants.SCIM_USER_SCHEMA};
+
         String json = mapper.writeValueAsString(newUser);
         byte[] jsonBytes = json.getBytes();
 
@@ -95,6 +97,8 @@ public class GHEnterpriseExt extends GHOrganization {
     }
 
     public SCIMEMUGroup createSCIMEMUGroup(SCIMEMUGroup newGroup) throws IOException {
+        newGroup.schemas = new String[]{SCIMConstants.SCIM_GROUP_SCHEMA};
+
         String json = mapper.writeValueAsString(newGroup);
         byte[] jsonBytes = json.getBytes();
 

--- a/src/main/java/org/kohsuke/github/GHEnterpriseExt.java
+++ b/src/main/java/org/kohsuke/github/GHEnterpriseExt.java
@@ -26,6 +26,9 @@ public class GHEnterpriseExt extends GHOrganization {
         try (InputStream inputStream = new ByteArrayInputStream(jsonBytes)) {
             SCIMEMUUser u = root.createRequest()
                     .method("POST")
+                    .withHeader(SCIMConstants.HEADER_CONTENT_TYPE, SCIMConstants.SCIM_CONTENT_TYPE)
+                    .withHeader(SCIMConstants.HEADER_ACCEPT, SCIMConstants.SCIM_ACCEPT)
+                    .withHeader(SCIMConstants.HEADER_API_VERSION, SCIMConstants.GITHUB_API_VERSION)
                     .with(inputStream)
                     .withUrlPath(String.format("/scim/v2/enterprises/%s/Users", login))
                     .fetch(SCIMEMUUser.class);
@@ -40,6 +43,9 @@ public class GHEnterpriseExt extends GHOrganization {
         try (InputStream inputStream = new ByteArrayInputStream(jsonBytes)) {
             SCIMEMUUser u = root.createRequest()
                     .method("PATCH")
+                    .withHeader(SCIMConstants.HEADER_CONTENT_TYPE, SCIMConstants.SCIM_CONTENT_TYPE)
+                    .withHeader(SCIMConstants.HEADER_ACCEPT, SCIMConstants.SCIM_ACCEPT)
+                    .withHeader(SCIMConstants.HEADER_API_VERSION, SCIMConstants.GITHUB_API_VERSION)
                     .with(inputStream)
                     .withUrlPath(String.format("/scim/v2/enterprises/%s/Users/%s", login, scimUserId))
                     .fetch(SCIMEMUUser.class);
@@ -49,6 +55,8 @@ public class GHEnterpriseExt extends GHOrganization {
 
     public SCIMEMUUser getSCIMEMUUser(String scimUserId) throws IOException {
         SCIMEMUUser u = root.createRequest()
+                .withHeader(SCIMConstants.HEADER_ACCEPT, SCIMConstants.SCIM_ACCEPT)
+                .withHeader(SCIMConstants.HEADER_API_VERSION, SCIMConstants.GITHUB_API_VERSION)
                 .withUrlPath(String.format("/scim/v2/enterprises/%s/Users/%s", login, scimUserId))
                 .fetch(SCIMEMUUser.class);
         return u;
@@ -56,6 +64,8 @@ public class GHEnterpriseExt extends GHOrganization {
 
     public SCIMEMUUser getSCIMEMUUserByUserName(String scimUserName) throws IOException {
         SCIMEMUUser u = root.createRequest()
+                .withHeader(SCIMConstants.HEADER_ACCEPT, SCIMConstants.SCIM_ACCEPT)
+                .withHeader(SCIMConstants.HEADER_API_VERSION, SCIMConstants.GITHUB_API_VERSION)
                 .withUrlPath(String.format("/scim/v2/enterprises/%s/Users?filter=userName eq \"%s\"", login, scimUserName))
                 .fetch(SCIMEMUUser.class);
         return u;
@@ -78,6 +88,8 @@ public class GHEnterpriseExt extends GHOrganization {
     public void deleteSCIMUser(String scimUserId) throws IOException {
         root.createRequest()
                 .method("DELETE")
+                .withHeader(SCIMConstants.HEADER_ACCEPT, SCIMConstants.SCIM_ACCEPT)
+                .withHeader(SCIMConstants.HEADER_API_VERSION, SCIMConstants.GITHUB_API_VERSION)
                 .withUrlPath(String.format("/scim/v2/enterprises/%s/Users/%s", login, scimUserId))
                 .send();
     }
@@ -89,6 +101,9 @@ public class GHEnterpriseExt extends GHOrganization {
         try (InputStream inputStream = new ByteArrayInputStream(jsonBytes)) {
             SCIMEMUGroup g = root.createRequest()
                     .method("POST")
+                    .withHeader(SCIMConstants.HEADER_CONTENT_TYPE, SCIMConstants.SCIM_CONTENT_TYPE)
+                    .withHeader(SCIMConstants.HEADER_ACCEPT, SCIMConstants.SCIM_ACCEPT)
+                    .withHeader(SCIMConstants.HEADER_API_VERSION, SCIMConstants.GITHUB_API_VERSION)
                     .with(inputStream)
                     .withUrlPath(String.format("/scim/v2/enterprises/%s/Groups", login))
                     .fetch(SCIMEMUGroup.class);
@@ -103,6 +118,9 @@ public class GHEnterpriseExt extends GHOrganization {
         try (InputStream inputStream = new ByteArrayInputStream(jsonBytes)) {
             SCIMEMUGroup g = root.createRequest()
                     .method("PATCH")
+                    .withHeader(SCIMConstants.HEADER_CONTENT_TYPE, SCIMConstants.SCIM_CONTENT_TYPE)
+                    .withHeader(SCIMConstants.HEADER_ACCEPT, SCIMConstants.SCIM_ACCEPT)
+                    .withHeader(SCIMConstants.HEADER_API_VERSION, SCIMConstants.GITHUB_API_VERSION)
                     .with(inputStream)
                     .withUrlPath(String.format("/scim/v2/enterprises/%s/Groups/%s", login, scimGroupId))
                     .fetch(SCIMEMUGroup.class);
@@ -112,6 +130,8 @@ public class GHEnterpriseExt extends GHOrganization {
 
     public SCIMEMUGroup getSCIMEMUGroup(String scimGroupId) throws IOException {
         SCIMEMUGroup g = root.createRequest()
+                .withHeader(SCIMConstants.HEADER_ACCEPT, SCIMConstants.SCIM_ACCEPT)
+                .withHeader(SCIMConstants.HEADER_API_VERSION, SCIMConstants.GITHUB_API_VERSION)
                 .withUrlPath(String.format("/scim/v2/enterprises/%s/Groups/%s", login, scimGroupId))
                 .fetch(SCIMEMUGroup.class);
         return g;
@@ -119,6 +139,8 @@ public class GHEnterpriseExt extends GHOrganization {
 
     public SCIMEMUGroup getSCIMEMUGroupByDisplayName(String scimGroupDisplayName) throws IOException {
         SCIMEMUGroup g = root.createRequest()
+                .withHeader(SCIMConstants.HEADER_ACCEPT, SCIMConstants.SCIM_ACCEPT)
+                .withHeader(SCIMConstants.HEADER_API_VERSION, SCIMConstants.GITHUB_API_VERSION)
                 .withUrlPath(String.format("/scim/v2/enterprises/%s/Groups?filter=displayName eq \"%s\"", login, scimGroupDisplayName))
                 .fetch(SCIMEMUGroup.class);
         return g;
@@ -141,6 +163,8 @@ public class GHEnterpriseExt extends GHOrganization {
     public void deleteSCIMGroup(String scimGroupId) throws IOException {
         root.createRequest()
                 .method("DELETE")
+                .withHeader(SCIMConstants.HEADER_ACCEPT, SCIMConstants.SCIM_ACCEPT)
+                .withHeader(SCIMConstants.HEADER_API_VERSION, SCIMConstants.GITHUB_API_VERSION)
                 .withUrlPath(String.format("/scim/v2/enterprises/%s/Groups/%s", login, scimGroupId))
                 .send();
     }

--- a/src/main/java/org/kohsuke/github/GHOrganizationExt.java
+++ b/src/main/java/org/kohsuke/github/GHOrganizationExt.java
@@ -46,6 +46,8 @@ public class GHOrganizationExt extends GHOrganization {
 
         SCIMUser u = root.createRequest()
                 .method("POST")
+                .withHeader(SCIMConstants.HEADER_ACCEPT, SCIMConstants.SCIM_ACCEPT)
+                .withHeader(SCIMConstants.GITHUB_API_VERSION, SCIMConstants.GITHUB_API_VERSION)
                 .with(map)
                 .withUrlPath(String.format("/scim/v2/organizations/%s/Users", login))
                 .fetch(SCIMUser.class);
@@ -81,6 +83,8 @@ public class GHOrganizationExt extends GHOrganization {
 
         SCIMUser u = root.createRequest()
                 .method("PATCH")
+                .withHeader(SCIMConstants.HEADER_ACCEPT, SCIMConstants.SCIM_ACCEPT)
+                .withHeader(SCIMConstants.GITHUB_API_VERSION, SCIMConstants.GITHUB_API_VERSION)
                 .with(map)
                 .withUrlPath(String.format("/scim/v2/organizations/%s/Users/%s", login, scimUserId))
                 .fetch(SCIMUser.class);
@@ -89,6 +93,8 @@ public class GHOrganizationExt extends GHOrganization {
 
     public SCIMUser getSCIMUser(String scimUserId) throws IOException {
         SCIMUser u = root.createRequest()
+                .withHeader(SCIMConstants.HEADER_ACCEPT, SCIMConstants.SCIM_ACCEPT)
+                .withHeader(SCIMConstants.GITHUB_API_VERSION, SCIMConstants.GITHUB_API_VERSION)
                 .withUrlPath(String.format("/scim/v2/organizations/%s/Users/%s", login, scimUserId))
                 .fetch(SCIMUser.class);
         return u;
@@ -96,6 +102,8 @@ public class GHOrganizationExt extends GHOrganization {
 
     public SCIMUser getSCIMUserByUserName(String scimUserName) throws IOException {
         SCIMUser u = root.createRequest()
+                .withHeader(SCIMConstants.HEADER_ACCEPT, SCIMConstants.SCIM_ACCEPT)
+                .withHeader(SCIMConstants.GITHUB_API_VERSION, SCIMConstants.GITHUB_API_VERSION)
                 .withUrlPath(String.format("/scim/v2/organizations/%s/Users?filter=userName eq \"%s\"", login, scimUserName))
                 .fetch(SCIMUser.class);
         return u;
@@ -132,6 +140,8 @@ public class GHOrganizationExt extends GHOrganization {
     public void deleteSCIMUser(String scimUserId) throws IOException {
         root.createRequest()
                 .method("DELETE")
+                .withHeader(SCIMConstants.HEADER_ACCEPT, SCIMConstants.SCIM_ACCEPT)
+                .withHeader(SCIMConstants.GITHUB_API_VERSION, SCIMConstants.GITHUB_API_VERSION)
                 .withUrlPath(String.format("/scim/v2/organizations/%s/Users/%s", login, scimUserId))
                 .send();
     }

--- a/src/main/java/org/kohsuke/github/SCIMConstants.java
+++ b/src/main/java/org/kohsuke/github/SCIMConstants.java
@@ -14,4 +14,7 @@ public final class SCIMConstants {
     public static final String HEADER_CONTENT_TYPE = "Content-Type";
     public static final String HEADER_ACCEPT = "Accept";
     public static final String HEADER_API_VERSION = "X-GitHub-Api-Version";
+
+    public static final String SCIM_USER_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:User";
+    public static final String SCIM_GROUP_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:Group";
 }

--- a/src/main/java/org/kohsuke/github/SCIMConstants.java
+++ b/src/main/java/org/kohsuke/github/SCIMConstants.java
@@ -1,0 +1,17 @@
+package org.kohsuke.github;
+
+/**
+ * Constants for SCIM API operations.
+ *
+ * @author Hiroyuki Wada
+ */
+public final class SCIMConstants {
+
+    public static final String SCIM_CONTENT_TYPE = "application/scim+json";
+    public static final String SCIM_ACCEPT = "application/scim+json";
+    public static final String GITHUB_API_VERSION = "2022-11-28";
+    
+    public static final String HEADER_CONTENT_TYPE = "Content-Type";
+    public static final String HEADER_ACCEPT = "Accept";
+    public static final String HEADER_API_VERSION = "X-GitHub-Api-Version";
+}

--- a/src/main/java/org/kohsuke/github/SCIMEMUGroup.java
+++ b/src/main/java/org/kohsuke/github/SCIMEMUGroup.java
@@ -7,6 +7,9 @@ import java.util.List;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SCIMEMUGroup {
+    @JsonProperty("schemas")
+    public String[] schemas;
+
     @JsonProperty("meta")
     public SCIMMeta meta;
 

--- a/src/main/java/org/kohsuke/github/SCIMEMUUser.java
+++ b/src/main/java/org/kohsuke/github/SCIMEMUUser.java
@@ -7,6 +7,9 @@ import java.util.List;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SCIMEMUUser {
+    @JsonProperty("schemas")
+    public String[] schemas;
+
     @JsonProperty("meta")
     public SCIMMeta meta;
 

--- a/src/main/java/org/kohsuke/github/SCIMPatchOperations.java
+++ b/src/main/java/org/kohsuke/github/SCIMPatchOperations.java
@@ -12,6 +12,7 @@ import java.util.stream.Collectors;
 public class SCIMPatchOperations {
     private static final String PATCH_OP = "urn:ietf:params:scim:api:messages:2.0:PatchOp";
 
+    @JsonProperty("schemas")
     public List<String> schemas = Collections.singletonList(PATCH_OP);
 
     @JsonProperty("Operations")

--- a/src/main/java/org/kohsuke/github/SCIMSearchBuilder.java
+++ b/src/main/java/org/kohsuke/github/SCIMSearchBuilder.java
@@ -23,7 +23,8 @@ public abstract class SCIMSearchBuilder<T> extends GHQueryBuilder<T> {
         this.organization = org;
         this.receiverType = receiverType;
         req.withUrlPath(getApiUrl());
-        req.rateLimit(RateLimitTarget.SEARCH);
+        req.withHeader(SCIMConstants.HEADER_ACCEPT, SCIMConstants.SCIM_ACCEPT);
+        req.withHeader(SCIMConstants.HEADER_API_VERSION, SCIMConstants.GITHUB_API_VERSION);
     }
 
     SCIMSearchBuilder(GitHub root, GHEnterpriseExt enterprise, Class<? extends SCIMSearchResult<T>> receiverType) {
@@ -32,7 +33,8 @@ public abstract class SCIMSearchBuilder<T> extends GHQueryBuilder<T> {
         this.organization = null;
         this.receiverType = receiverType;
         req.withUrlPath(getApiUrl());
-        req.rateLimit(RateLimitTarget.SEARCH);
+        req.withHeader(SCIMConstants.HEADER_ACCEPT, SCIMConstants.SCIM_ACCEPT);
+        req.withHeader(SCIMConstants.HEADER_API_VERSION, SCIMConstants.GITHUB_API_VERSION);
     }
 
     /**


### PR DESCRIPTION
Add Accept and X-GitHub-Api-Version headers to all SCIM API requests, and Content-Type header for requests with body, to ensure proper content negotiation and API version specification for GitHub SCIM endpoints.